### PR TITLE
Added button component menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class MySource(menus.ListPageSource):
         return '\n'.join(f'{i}. {v}' for i, v in enumerate(entries, start=offset))
 
 # somewhere else:
-pages = menus.MenuPages(source=MySource(range(1, 100)))
+pages = menus.MenuPages(source=MySource(range(1, 100)), clear_reactions_after=True)
 await pages.start(ctx)
 ```
 
@@ -220,10 +220,12 @@ A `ButtonMenuPages` class is provided for pagination with button components.
 
 `ButtonMenuPages` works the same way as the `MenuPages` class found above, but with button components instead of reactions.
 
+A `ButtonStyle` can optionally be passed in to customize the appearance.
+
 `MySource` is the same as defined above, but the menu is instantiated with:
 
 ```py
-pages = menus.ButtonMenuPages(source=MySource(range(1, 100)), clear_reactions_after=True)
+pages = menus.ButtonMenuPages(source=MySource(range(1, 100)), style=nextcord.ButtonStyle.primary)
 await pages.start(ctx)
 ```
 

--- a/README.md
+++ b/README.md
@@ -188,15 +188,15 @@ class MyButtonMenu(menus.Menu, nextcord.ui.View):
         nextcord.ui.View.__init__(self)
 
     async def send_initial_message(self, ctx, channel):
-        self._message = await channel.send(f'Hello {ctx.author}', view=self)
+        return await channel.send(f'Hello {ctx.author}', view=self)
 
     @nextcord.ui.button(emoji="\N{THUMBS UP SIGN}")
     async def on_thumbs_up(self, button, interaction):
-        await self._message.edit(content=f"Thanks {interaction.user}!")
+        await self.message.edit(content=f"Thanks {interaction.user}!")
 
     @nextcord.ui.button(emoji="\N{THUMBS DOWN SIGN}")
     async def on_thumbs_down(self, button, interaction):
-        await self._message.edit(content=f"That's not nice {interaction.user}...")
+        await self.message.edit(content=f"That's not nice {interaction.user}...")
 
     @nextcord.ui.button(emoji="\N{BLACK SQUARE FOR STOP}\ufe0f")
     async def on_stop(self, button, interaction):

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ Now, within a command we just instantiate it and we start it like so:
 ```py
 @bot.command()
 async def menu_example(ctx):
-    m = MyMenu()
-    await m.start(ctx)
+    await MyMenu().start(ctx)
 ```
 
 If an error happens then an exception of type `menus.MenuError` is raised.
@@ -183,7 +182,7 @@ Button implementation of a basic menu that has a stop button and two reply react
 import nextcord
 from nextcord.ext import menus
 
-class MyMenu(menus.Menu, nextcord.ui.View):
+class MyButtonMenu(menus.Menu, nextcord.ui.View):
     def __init__(self):
         menus.Menu.__init__(self)
         nextcord.ui.View.__init__(self)
@@ -206,13 +205,17 @@ class MyMenu(menus.Menu, nextcord.ui.View):
 
 Instantiation is the same as above.
 
+```py
+await MyButtonMenu().start(ctx)
+```
+
 ### Pagination
 
 A `ButtonMenuPages` class is provided for pagination with button components.
 
 `ButtonMenuPages` works the same way as the `MenuPages` class found above, but with button components instead of reactions.
 
-`MySource` is the same as defined above but instantiated with:
+`MySource` is the same as defined above, but instantiated with:
 
 ```py
 pages = menus.ButtonMenuPages(source=MySource(range(1, 100)), clear_reactions_after=True)

--- a/README.md
+++ b/README.md
@@ -176,17 +176,19 @@ await pages.start(ctx)
 
 ## Button Component Menus
 
-Here is a button implementation of a basic menu that has a stop button and two reply reactions. Note that the `ButtonMenu` class is used instead of `Menu` in order to make it a `View`.
+Here is a button implementation of a basic menu that has a stop button and two reply reactions.
 
-`ButtonMenu` is a subclass of `Menu` and it therefore has all the same attributes and methods.
+Note that `view=self` is passed with the initial message and `nextcord.ui.button` is used instead of `menus.button`.
 
-Also note that `ButtonMenu.stop()` is a coroutine and needs to be awaited.
+`Menu.disable()` can be used to disable all buttons in the menu.
+
+`Menu.enable()` can be used to enable all buttons in the menu.
 
 ```py
 import nextcord
 from nextcord.ext import menus
 
-class MyButtonMenu(menus.ButtonMenu):
+class MyButtonMenu(menus.Menu):
     async def send_initial_message(self, ctx, channel):
         return await channel.send(f'Hello {ctx.author}', view=self)
 
@@ -200,7 +202,8 @@ class MyButtonMenu(menus.ButtonMenu):
 
     @nextcord.ui.button(emoji="\N{BLACK SQUARE FOR STOP}\ufe0f")
     async def on_stop(self, button, interaction):
-        await self.stop()
+        await self.disable()
+        self.stop()
 ```
 
 Instantiation is the same as above.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,15 @@ class MyMenu(menus.Menu, nextcord.ui.View):
 
 Instantiation is the same as above.
 
+### Pagination
+
+`MySource` is the same as defined above but instantiated with:
+
+```py
+pages = menus.ButtonMenuPages(source=MySource(range(1, 100)), clear_reactions_after=True)
+await pages.start(ctx)
+```
+
 ## License
 
 Copyright (c) 2021 The Nextcord Developers  

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # nextcord-ext-menus
 
-## About 
+# About 
 
 A Nextcord extension that makes working with reaction menus a bit easier.
 
-## Installing
+# Installing
 
 Python **>=3.6.0** is required.
 
@@ -12,7 +12,9 @@ Python **>=3.6.0** is required.
 pip install --upgrade nextcord-ext-menus
 ```
 
-## Getting Started
+# Getting Started
+
+## Reaction Menus
 
 To whet your appetite, the following examples show the fundamentals on how to create menus.
 
@@ -174,6 +176,37 @@ class Source(menus.AsyncIteratorPageSource):
 pages = menus.MenuPages(source=Source(), clear_reactions_after=True)
 await pages.start(ctx)
 ```
+
+## Button Component Menus
+
+The first example shows a basic menu that has a stop button and two reply reactions:
+
+```py
+import nextcord
+from nextcord.ext import menus
+
+class MyMenu(menus.Menu, nextcord.ui.View):
+    def __init__(self):
+        menus.Menu.__init__(self)
+        nextcord.ui.View.__init__(self)
+
+    async def send_initial_message(self, ctx, channel):
+        self._message = await channel.send(f'Hello {ctx.author}', view=self)
+
+    @nextcord.ui.button(emoji="\N{THUMBS UP SIGN}")
+    async def on_thumbs_up(self, button, interaction):
+        await self._message.edit(content=f"Thanks {interaction.user}!")
+
+    @nextcord.ui.button(emoji="\N{THUMBS DOWN SIGN}")
+    async def on_thumbs_down(self, button, interaction):
+        await self._message.edit(content=f"That's not nice {interaction.user}...")
+
+    @nextcord.ui.button(emoji="\N{BLACK SQUARE FOR STOP}\ufe0f")
+    async def on_stop(self, button, interaction):
+        nextcord.ui.View.stop(self)
+```
+
+Instantiation is the same as above.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -178,17 +178,19 @@ await pages.start(ctx)
 
 Here is a button implementation of a basic menu that has a stop button and two reply reactions.
 
-Note that `view=self` is passed with the initial message and `nextcord.ui.button` is used instead of `menus.button`.
+Note that the `ButtonMenu` class is used instead of `Menu` in order to make it a `View`. `ButtonMenu` is a subclass of `Menu` and it therefore has all the same attributes and methods.
 
-`Menu.disable()` can be used to disable all buttons in the menu.
+Also note that `view=self` is passed with the initial message and `nextcord.ui.button` is used instead of `menus.button`.
 
-`Menu.enable()` can be used to enable all buttons in the menu.
+`ButtonMenu.disable` can be used to disable all buttons in the menu.
+
+`ButtonMenu.enable` can be used to enable all buttons in the menu.
 
 ```py
 import nextcord
 from nextcord.ext import menus
 
-class MyButtonMenu(menus.Menu):
+class MyButtonMenu(menus.ButtonMenu):
     async def send_initial_message(self, ctx, channel):
         return await channel.send(f'Hello {ctx.author}', view=self)
 

--- a/README.md
+++ b/README.md
@@ -212,20 +212,7 @@ A `ButtonMenuPages` class is provided for pagination with button components.
 
 `ButtonMenuPages` works the same way as the `MenuPages` class found above, but with button components instead of reactions.
 
-Here is a basic list source for button pagination:
-
-```py
-class MySource(menus.ListPageSource, nextcord.ui.View):
-    def __init__(self, data):
-        menus.ListPageSource.__init__(self, data, per_page=4)
-        nextcord.ui.View.__init__(self)
-
-    async def format_page(self, menu, entries):
-        offset = menu.current_page * self.per_page
-        return '\n'.join(f'{i}. {v}' for i, v in enumerate(entries, start=offset))
-```
-
-The menu is instantiated with:
+`MySource` is the same as defined above but instantiated with:
 
 ```py
 pages = menus.ButtonMenuPages(source=MySource(range(1, 100)), clear_reactions_after=True)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,20 @@ A `ButtonMenuPages` class is provided for pagination with button components.
 
 `ButtonMenuPages` works the same way as the `MenuPages` class found above, but with button components instead of reactions.
 
-`MySource` is the same as defined above but instantiated with:
+Here is a basic list source for button pagination:
+
+```py
+class MySource(menus.ListPageSource, nextcord.ui.View):
+    def __init__(self, data):
+        menus.ListPageSource.__init__(self, data, per_page=4)
+        nextcord.ui.View.__init__(self)
+
+    async def format_page(self, menu, entries):
+        offset = menu.current_page * self.per_page
+        return '\n'.join(f'{i}. {v}' for i, v in enumerate(entries, start=offset))
+```
+
+The menu is instantiated with:
 
 ```py
 pages = menus.ButtonMenuPages(source=MySource(range(1, 100)), clear_reactions_after=True)

--- a/README.md
+++ b/README.md
@@ -176,17 +176,17 @@ await pages.start(ctx)
 
 ## Button Component Menus
 
-Button implementation of a basic menu that has a stop button and two reply reactions:
+Here is a button implementation of a basic menu that has a stop button and two reply reactions. Note that the `ButtonMenu` class is used instead of `Menu` in order to make it a `View`.
+
+`ButtonMenu` is a subclass of `Menu` and it therefore has all the same attributes and methods.
+
+Also note that `ButtonMenu.stop()` is a coroutine and needs to be awaited.
 
 ```py
 import nextcord
 from nextcord.ext import menus
 
-class MyButtonMenu(menus.Menu, nextcord.ui.View):
-    def __init__(self):
-        menus.Menu.__init__(self)
-        nextcord.ui.View.__init__(self)
-
+class MyButtonMenu(menus.ButtonMenu):
     async def send_initial_message(self, ctx, channel):
         return await channel.send(f'Hello {ctx.author}', view=self)
 
@@ -200,7 +200,7 @@ class MyButtonMenu(menus.Menu, nextcord.ui.View):
 
     @nextcord.ui.button(emoji="\N{BLACK SQUARE FOR STOP}\ufe0f")
     async def on_stop(self, button, interaction):
-        nextcord.ui.View.stop(self)
+        await self.stop()
 ```
 
 Instantiation is the same as above.
@@ -215,7 +215,7 @@ A `ButtonMenuPages` class is provided for pagination with button components.
 
 `ButtonMenuPages` works the same way as the `MenuPages` class found above, but with button components instead of reactions.
 
-`MySource` is the same as defined above, but instantiated with:
+`MySource` is the same as defined above, but the menu is instantiated with:
 
 ```py
 pages = menus.ButtonMenuPages(source=MySource(range(1, 100)), clear_reactions_after=True)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class MySource(menus.ListPageSource):
         return '\n'.join(f'{i}. {v}' for i, v in enumerate(entries, start=offset))
 
 # somewhere else:
-pages = menus.MenuPages(source=MySource(range(1, 100)), clear_reactions_after=True)
+pages = menus.MenuPages(source=MySource(range(1, 100)))
 await pages.start(ctx)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # nextcord-ext-menus
 
-# About 
-
-A Nextcord extension that makes working with reaction menus a bit easier.
+A Nextcord extension that makes working with reaction menus and button component menus a bit easier.
 
 # Installing
 
@@ -179,7 +177,7 @@ await pages.start(ctx)
 
 ## Button Component Menus
 
-The first example shows a basic menu that has a stop button and two reply reactions:
+Button implementation of a basic menu that has a stop button and two reply reactions:
 
 ```py
 import nextcord
@@ -209,6 +207,10 @@ class MyMenu(menus.Menu, nextcord.ui.View):
 Instantiation is the same as above.
 
 ### Pagination
+
+A `ButtonMenuPages` class is provided for pagination with button components.
+
+`ButtonMenuPages` works the same way as the `MenuPages` class found above, but with button components instead of reactions.
 
 `MySource` is the same as defined above but instantiated with:
 

--- a/nextcord/ext/menus/__init__.py
+++ b/nextcord/ext/menus/__init__.py
@@ -1138,7 +1138,7 @@ class ButtonMenuPages(MenuPagesBase):
         The current page that we are in. Zero-indexed
         between [0, :attr:`PageSource.max_pages`).
     """
-    def __init__(self, source: PageSource, style: nextcord.ButtonStyle = nextcord.ButtonStyle.primary, **kwargs):
+    def __init__(self, source: PageSource, style: nextcord.ButtonStyle = nextcord.ButtonStyle.secondary, **kwargs):
         super().__init__(source, **kwargs)
         # add buttons to the view
         for emoji in (self.FIRST_PAGE, self.PREVIOUS_PAGE, self.NEXT_PAGE, self.LAST_PAGE, self.STOP):


### PR DESCRIPTION
Added a class `ButtonMenu` that extends `Menu` for easily implementing menus with button components.

I have also added a helper class `ButtonMenuPages` which is the button component equivalent to `MenuPages`.

- [x] Basic button menus
  - [x] can disable all buttons
- [x] Button menu with `wait=true`
- [x] Button Pagination
  - [x] Buttons disabled when unavailable
  - [x] Can use custom ButtonStyle
  - [x] Group By Page Source
  - [x] Async Iterator Page Source

![pages](https://user-images.githubusercontent.com/20955511/132067033-ddb60c5f-8515-4f78-842f-83b8e1d60a84.gif)

Discord bot for testing nextcord-ext-menus:

https://gist.github.com/DenverCoder1/b734a220ac108d024228a22772a89cd1