### PR TITLE
Fix for pip command not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A Nextcord extension that makes working with reaction menus a bit easier.
 
 ## Installing
 
-Python **>=3.6.0** is required.
+Python **>=3.8** is required.
 
 ```py 
-pip install --upgrade nextcord-ext-menus
+pip install --upgrade git+https://github.com/nextcord/nextcord-ext-menus.git
 ```
 
 ## Getting Started

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,11 @@ if version.endswith(('a', 'b', 'rc')):
         pass
 
 setup(name='nextcord-ext-menus',
-      author='Nextcord Developers',
+      author='Rapptz & Nextcord Developers',
       url='https://github.com/nextcord/nextcord-ext-menus',
       version=version,
       packages=['nextcord.ext.menus'],
       license='MIT',
-      description='An extension module to make reaction based menus with nextcord',
-      python_requires='>=3.6.0'
+      description='An extension module to make reaction and button based menus with nextcord',
+      python_requires='>=3.8.0'
 )


### PR DESCRIPTION
Fixed by changing command to

```
pip install --upgrade git+https://github.com/nextcord/nextcord-ext-menus.git
```

If nextcord-ext-menus is added to pypi, this won't be necessary.

Fixes #2 