### PR TITLE
Added disable_buttons_after kwarg to ButtonMenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,16 @@ Also note that `view=self` is passed with the initial message and `nextcord.ui.b
 
 `ButtonMenu.enable` can be used to enable all buttons in the menu.
 
+Additionally, `disable_buttons_after` can be used as a kwarg to ButtonMenu to disable all buttons when the menu stops and `clear_buttons_after` can be used to remove them.
+
 ```py
 import nextcord
 from nextcord.ext import menus
 
 class MyButtonMenu(menus.ButtonMenu):
+    def __init__(self):
+        super().__init__(disable_buttons_after=True)
+
     async def send_initial_message(self, ctx, channel):
         return await channel.send(f'Hello {ctx.author}', view=self)
 
@@ -218,7 +223,6 @@ class MyButtonMenu(menus.ButtonMenu):
 
     @nextcord.ui.button(emoji="\N{BLACK SQUARE FOR STOP}\ufe0f")
     async def on_stop(self, button, interaction):
-        await self.disable()
         self.stop()
 ```
 

--- a/nextcord/ext/menus/__init__.py
+++ b/nextcord/ext/menus/__init__.py
@@ -6,4 +6,4 @@ from .page_source import *
 from .utils import *
 
 # Needed for the setup.py script
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -502,8 +502,10 @@ class Menu(metaclass=_MenuMeta):
 
             if self.delete_message_after:
                 await self.message.delete()
-            elif self.clear_reactions_after:
+            elif getattr(self, "clear_buttons_after", self.clear_reactions_after):
                 await self.clear()
+            elif getattr(self, "disable_buttons_after", None):
+                await self.disable()
 
     async def update(self, payload: nextcord.RawReactionActionEvent):
         """|coro|
@@ -700,12 +702,17 @@ class ButtonMenu(Menu, nextcord.ui.View):
     clear_buttons_after: :class:`bool`
         Whether to clear buttons after the menu interaction is done.
         Note that :attr:`delete_message_after` takes priority over this attribute.
+    disable_buttons_after: :class:`bool`
+        Whether to disable all buttons after the menu interaction is done.
+        Note that :attr:`delete_message_after` and :attr:`clear_buttons_after` take priority over this attribute.
     """
 
-    def __init__(self, timeout: float = DEFAULT_TIMEOUT, clear_buttons_after: bool = False, *args, **kwargs):
-        kwargs["clear_reactions_after"] = kwargs.get("clear_reactions_after", clear_buttons_after)
+    def __init__(self, timeout: float = DEFAULT_TIMEOUT, clear_buttons_after: bool = False,
+                 disable_buttons_after: bool = False, *args, **kwargs):
         Menu.__init__(self, timeout=timeout, *args, **kwargs)
         nextcord.ui.View.__init__(self, timeout=timeout)
+        self.clear_buttons_after = clear_buttons_after
+        self.disable_buttons_after = disable_buttons_after
 
     async def _update_view(self):
         await self.message.edit(view=self)


### PR DESCRIPTION
Added the ability to automatically disable all buttons on timeout or stop by simply passing `disable_buttons_after=True` to the `ButtonMenu` constructor.