### PR TITLE
Allow `inherit_buttons=False` to skip ButtonMenuPages buttons

### DIFF
--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -218,6 +218,9 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
     def __init__(self, source: PageSource, style: nextcord.ButtonStyle = nextcord.ButtonStyle.secondary, **kwargs):
         self.__button_menu_pages__ = True
         super().__init__(source, **kwargs)
+        # skip adding buttons if inherit_buttons=False was passed to metaclass
+        if not self.__inherit_buttons__:
+            return
         # add buttons to the view
         for emoji in (self.FIRST_PAGE, self.PREVIOUS_PAGE, self.NEXT_PAGE, self.LAST_PAGE, self.STOP):
             if emoji in {self.FIRST_PAGE, self.LAST_PAGE} and self._skip_double_triangle_buttons():

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -182,6 +182,7 @@ class _MenuMeta(type):
                 else:
                     buttons.append(value)
 
+        new_cls.__inherit_buttons__ = inherit_buttons
         new_cls.__menu_buttons__ = buttons
         return new_cls
 


### PR DESCRIPTION
Allows inheriting from `ButtonMenuPages` but not inheriting buttons, allowing the developer to use menu page methods with a custom selection of buttons.

**Example code:**

```py
class CustomButtonMenuPages(menus.ButtonMenuPages, inherit_buttons=False):
    def __init__(self, source: dict, timeout: int = 60):
        super().__init__(source, timeout=timeout, delete_message_after=True)

    @nextcord.ui.button(emoji="\N{BLACK LEFT-POINTING TRIANGLE}\N{VARIATION SELECTOR-16}")
    async def go_back(self, button, interaction):
        if self.current_page == 0:
            await self.show_page(self._source.get_max_pages() - 1)
        else:
            await self.show_checked_page(self.current_page - 1)

    @nextcord.ui.button(emoji="\N{BLACK RIGHT-POINTING TRIANGLE}\N{VARIATION SELECTOR-16}")
    async def go_next(self, button, interaction):
        if self.current_page == self._source.get_max_pages() - 1:
            await self.show_page(0)
        else:
            await self.show_checked_page(self.current_page + 1)
```

```py
# start custom button menu pages
pages = CustomButtonMenuPages(source=MySource(range(1, 100)))
await pages.start(ctx)
```

![image](https://user-images.githubusercontent.com/20955511/133943049-5f123536-fd64-424a-954c-007e18ede5a5.png)
