### PR TITLE
Slight changes to MenuPaginationButton constructor

### DIFF
--- a/nextcord/ext/menus/constants.py
+++ b/nextcord/ext/menus/constants.py
@@ -12,7 +12,7 @@ DEFAULT_TIMEOUT = 180.0
 
 # type definition for the keyword-arguments that are
 # used in both Message.edit and Messageable.send
-SendKwargsType = Dict[str, Union[str, nextcord.Embed, None]]
+SendKwargsType = Dict[str, Union[str, nextcord.Embed, nextcord.ui.View, None]]
 
 # type definition for possible page formats
 PageFormatType = Union[str, nextcord.Embed, SendKwargsType]

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -167,14 +167,17 @@ class MenuPaginationButton(nextcord.ui.Button['MenuPaginationButton']):
     A custom button for pagination that will be disabled when unavailable.
     """
 
-    def __init__(self, style: nextcord.ButtonStyle, emoji: EmojiType):
-        super().__init__(style=style, emoji=emoji)
-        self._emoji = _cast_emoji(emoji)
+    def __init__(self, emoji: Optional[EmojiType] = None, **kwargs):
+        super().__init__(emoji=emoji, **kwargs)
+        self._emoji = _cast_emoji(emoji) if emoji else None
 
     async def callback(self, interaction: nextcord.Interaction):
         """
         Callback for when this button is pressed
         """
+        if not isinstance(self._emoji, nextcord.Emoji):
+            return
+
         assert self.view is not None
         view: ButtonMenuPages = self.view
 
@@ -225,7 +228,7 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
         for emoji in (self.FIRST_PAGE, self.PREVIOUS_PAGE, self.NEXT_PAGE, self.LAST_PAGE, self.STOP):
             if emoji in {self.FIRST_PAGE, self.LAST_PAGE} and self._skip_double_triangle_buttons():
                 continue
-            self.add_item(MenuPaginationButton(style=style, emoji=emoji))
+            self.add_item(MenuPaginationButton(emoji=emoji, style=style))
         self._disable_unavailable_buttons()
 
     def _disable_unavailable_buttons(self):

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -169,7 +169,7 @@ class MenuPaginationButton(nextcord.ui.Button['MenuPaginationButton']):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        emoji = kwargs.get(emoji, None)
+        emoji = kwargs.get("emoji", None)
         self._emoji = _cast_emoji(emoji) if emoji else None
 
     async def callback(self, interaction: nextcord.Interaction):

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -175,7 +175,7 @@ class MenuPaginationButton(nextcord.ui.Button['MenuPaginationButton']):
         """
         Callback for when this button is pressed
         """
-        if not isinstance(self._emoji, nextcord.Emoji):
+        if self._emoji is None:
             return
 
         assert self.view is not None

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -167,8 +167,9 @@ class MenuPaginationButton(nextcord.ui.Button['MenuPaginationButton']):
     A custom button for pagination that will be disabled when unavailable.
     """
 
-    def __init__(self, emoji: Optional[EmojiType] = None, **kwargs):
-        super().__init__(emoji=emoji, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        emoji = kwargs.get(emoji, None)
         self._emoji = _cast_emoji(emoji) if emoji else None
 
     async def callback(self, interaction: nextcord.Interaction):


### PR DESCRIPTION
Modified `MenuPaginationButton` constructor to take any keyword arguments so that when inheriting from `ButtonMenuPages` or customizing the available buttons, the user can add buttons using `MenuPaginationButton()`, thereby using the provided button callback assuming the emojis used are the same.

This change simplifies the code, but also allows users to incorporate `MenuPaginationButton` in their code with `label`, `custom_id`, `row`, etc.

[Additionally, `nextcord.ui.View` was added to the type annotation for send-method kwargs since that is the type for the `view` kwarg.]

### Note:

May cause breaking changes in rare cases if `MenuPaginationButton` is used in users' code without keywording the emoji and style arguments. There is almost no reason to need to use `MenuPaginationButton` directly instead of simply using `ButtonMenuPages`, so I doubt any code will be broken by this change.

### Examples of how a user may use `MenuPaginationButton`

1. Customizing which buttons appear in the menu by inheriting `ButtonMenuPages` without buttons:

```py
class CustomButtonMenuPages(menus.ButtonMenuPages, inherit_buttons=False):
    def __init__(self, source: menus.PageSource, timeout: int = 60):
        super().__init__(source, timeout=timeout, delete_message_after=True)
        self.add_item(MenuPaginationButton(emoji=self.PREVIOUS_PAGE))
        self.add_item(MenuPaginationButton(emoji=self.NEXT_PAGE))
        self.add_item(MenuPaginationButton(emoji=self.STOP))
        self._disable_unavailable_buttons()

# start menu
pages = CustomButtonMenuPages(source=MySource(range(1, 100)))
await pages.start(ctx)
```

2. Choose which buttons are displayed for each page individually with a custom PageSource:

```py
class MyCustomButtonSource(menus.ListPageSource):
    def __init__(self, data):
        super().__init__(data, per_page=4)

    async def format_page(self, menu: menus.ButtonMenuPages, entries: list) -> menus.SendKwargsType:
        offset = menu.current_page * self.per_page
        menu.clear_items()
        if menu.current_page > 0:
            menu.add_item(menus.MenuPaginationButton(
                emoji=menu.PREVIOUS_PAGE, label="Prev"))
        if menu.current_page < self.get_max_pages() - 1:
            menu.add_item(menus.MenuPaginationButton(
                emoji=menu.NEXT_PAGE, label="Next"))
        return {
            "content": '\n'.join(f'{i}. {v}' for i, v in enumerate(entries, start=offset)),
            "view": menu
        }

# start menu
pages = ButtonMenuPages(source=MyCustomButtonSource(range(1, 100)))
await pages.start(ctx)
```



