### PR TITLE
Combine separate edits into one

### DIFF
--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -69,7 +69,10 @@ class MenuPagesBase(Menu):
         return self._source.is_paginating()
 
     async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
-        """Calls :meth:`PageSource.format_page` and returns a dict of send kwargs"""
+        """|coro|
+        
+        Calls :meth:`PageSource.format_page` and returns a dict of send kwargs
+        """
         value: PageFormatType = await nextcord.utils.maybe_coroutine(self._source.format_page, self, page)
         if isinstance(value, dict):
             return value
@@ -79,6 +82,10 @@ class MenuPagesBase(Menu):
             return {'embed': value, 'content': None}
 
     async def show_page(self, page_number: int):
+        """|coro|
+
+        Sets the current page to the specified page and shows it.
+        """
         page = await self._source.get_page(page_number)
         self.current_page = page_number
         kwargs = await self._get_kwargs_from_page(page)
@@ -234,13 +241,24 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
             if emoji in {self.FIRST_PAGE, self.LAST_PAGE} and self._skip_double_triangle_buttons():
                 continue
             self.add_item(MenuPaginationButton(emoji=emoji, style=style))
+
+    async def show_page(self, page_number: int):
+        """|coro|
+
+        Sets the current page to the specified page and shows it.
+        """
+        # disable buttons that are not available
+        self.current_page = page_number
         self._disable_unavailable_buttons()
+        # show the page
+        await super().show_page(page_number)
 
     async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
-        """Calls :meth:`PageSource.format_page` and returns a dict of send kwargs"""
+        """|coro|
+        
+        Calls :meth:`PageSource.format_page` and returns a dict of send kwargs
+        """
         kwargs = await super()._get_kwargs_from_page(page)
-        # mark unavailable buttons as disabled
-        self._disable_unavailable_buttons()
         # add view to kwargs if it's not already there
         return {"view": self, **kwargs}
 

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -70,7 +70,7 @@ class MenuPagesBase(Menu):
 
     async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
         """|coro|
-        
+
         Calls :meth:`PageSource.format_page` and returns a dict of send kwargs
         """
         value: PageFormatType = await nextcord.utils.maybe_coroutine(self._source.format_page, self, page)
@@ -209,7 +209,7 @@ class MenuPaginationButton(nextcord.ui.Button['MenuPaginationButton']):
         elif str(self._emoji) == view.LAST_PAGE:
             await view.go_to_last_page()
         elif str(self._emoji) == view.STOP:
-            return view.stop()
+            await view.stop_pages()
 
 
 class ButtonMenuPages(MenuPagesBase, ButtonMenu):
@@ -241,6 +241,8 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
             if emoji in {self.FIRST_PAGE, self.LAST_PAGE} and self._skip_double_triangle_buttons():
                 continue
             self.add_item(MenuPaginationButton(emoji=emoji, style=style))
+        # disable buttons that are not available
+        self._disable_unavailable_buttons()
 
     async def show_page(self, page_number: int):
         """|coro|
@@ -255,7 +257,7 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
 
     async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
         """|coro|
-        
+
         Calls :meth:`PageSource.format_page` and returns a dict of send kwargs
         """
         kwargs = await super()._get_kwargs_from_page(page)


### PR DESCRIPTION
Fixes #18 

Previously, `ButtonMenuPages` updates the menu message two times (one to update the content/embed and another to update the view). This PR consolidates the two edits into a single request for efficiency.

The `view` kwarg was added to an override of `_get_kwargs_from_page` so that `ButtonMenuPages` will always make sure the view is updated when editing the menu and there is no need to update the view at the end of the button callback.

### Note:

* The call to `_disable_unavailable_buttons()` now happens in `show_page()` instead of the Button callback.
* `_get_kwargs_from_page()` for ButtonMenuPages will always include `view` as a key.