### PR TITLE
fix: AsyncIterator buttons not getting displayed

### DIFF
--- a/nextcord/ext/menus/__init__.py
+++ b/nextcord/ext/menus/__init__.py
@@ -6,4 +6,4 @@ from .page_source import *
 from .utils import *
 
 # Needed for the setup.py script
-__version__ = "1.3.3"
+__version__ = "1.3.4"

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -121,6 +121,9 @@ class MenuPagesBase(Menu):
     ):
         await self._source._prepare_once()
         await super().start(ctx, channel=channel, wait=wait)
+        # If we're not paginating, we can remove the pagination buttons
+        if not self._source.is_paginating():
+            await self.clear()
 
     async def show_checked_page(self, page_number: int):
         max_pages = self._source.get_max_pages()

--- a/nextcord/ext/menus/page_source.py
+++ b/nextcord/ext/menus/page_source.py
@@ -339,7 +339,10 @@ class AsyncIteratorPageSource(PageSource):
 
     def is_paginating(self) -> bool:
         """:class:`bool`: Whether pagination is required."""
-        return len(self._cache) > self.per_page
+        # If we have not prepared yet, we do not know if we are paginating, so we return True
+        # This is to ensure that the buttons will be created in the case we are paginating
+        # If we have prepared, but we are exhausted before 1 page, we are not paginating
+        return not self._cache or len(self._cache) > self.per_page
 
     async def _get_single_page(self, page_number: int) -> DataType:
         if page_number < 0:


### PR DESCRIPTION
This is a hotfix to 1.3.3 where AsyncIteratorPageSource stopped working due to #24 

Note:

When using AsyncIteratorPageSource when there is only 1 page, the buttons get displayed for a split second before they get removed in start(). This is an extremely rare use case, but should be mentioned regardless.