### PR TITLE
feat: Support for menu in interaction response

### DIFF
--- a/docs/ext/menus/menu_examples.rst
+++ b/docs/ext/menus/menu_examples.rst
@@ -176,12 +176,14 @@ the :class:`ButtonMenu` in the same way as shown before.
 Slash Commands
 --------------
 
-To use a menu in a slash command, we need to pass ``interaction`` to :meth:`start() <Menu.start>` instead of ``ctx``.
+To use a menu in a slash command or component response, we need to pass ``interaction`` to :meth:`start() <Menu.start>` instead of ``ctx``.
 
 ``interaction`` must be passed as a keyword argument.
 
 Additionally, we will use :meth:`interaction.response.send_message() <nextcord.InteractionResponse.send_message>`
 in the :meth:`send_initial_message() <Menu.send_initial_message>` method to send the initial message.
+
+To make the response message ephemeral, we can pass ``ephemeral=True`` to :meth:`start() <Menu.start>` as well.
 
 .. code:: py
 

--- a/docs/ext/menus/menu_examples.rst
+++ b/docs/ext/menus/menu_examples.rst
@@ -171,3 +171,37 @@ the :class:`ButtonMenu` in the same way as shown before.
     async def button_confirm(ctx):
         confirm = await ButtonConfirm("Confirm?").prompt(ctx)
         await ctx.send(f"You said: {confirm}")
+
+
+Slash Commands
+--------------
+
+To use a menu in a slash command, we need to pass ``interaction`` to :meth:`start() <Menu.start>` instead of ``ctx``.
+
+``interaction`` must be passed as a keyword argument.
+
+Additionally, we will use :meth:`interaction.response.send_message() <nextcord.InteractionResponse.send_message>`
+in the :meth:`send_initial_message() <Menu.send_initial_message>` method to send the initial message.
+
+.. code:: py
+
+    class MySlashButtonMenu(menus.ButtonMenu):
+        async def send_initial_message(self, ctx, channel):
+            await self.interaction.response.send_message(f"Hello {self.interaction.user}", view=self)
+            return await self.interaction.original_message()
+
+        @nextcord.ui.button(emoji="\N{THUMBS UP SIGN}")
+        async def on_thumbs_up(self, button, interaction):
+            await self.message.edit(content=f"Thanks {interaction.user}!")
+
+        @nextcord.ui.button(emoji="\N{THUMBS DOWN SIGN}")
+        async def on_thumbs_down(self, button, interaction):
+            await self.message.edit(content=f"That's not nice {interaction.user}...")
+
+        @nextcord.ui.button(emoji="\N{BLACK SQUARE FOR STOP}\ufe0f")
+        async def on_stop(self, button, interaction):
+            self.stop()
+
+    @bot.slash_command(guild_ids=[TESTING_GUILD_ID], name="slashmenu")
+    async def slash_menu_example(interaction: nextcord.Interaction):
+        await MySlashButtonMenu().start(interaction=interaction)

--- a/docs/ext/menus/pagination_examples.rst
+++ b/docs/ext/menus/pagination_examples.rst
@@ -328,6 +328,9 @@ for an example on how to create a :class:`Select Menu <nextcord.ui.Select>`.
 Menu in Slash Command Response
 ------------------------------
 
+To use a menu in a slash command, we need to pass ``interaction`` to :meth:`start() <Menu.start>` 
+as a keyword argument instead of ``ctx``.
+
 .. code:: py
 
     @bot.slash_command(guild_ids=[TEST_GUILD_ID], name="slashpages")

--- a/docs/ext/menus/pagination_examples.rst
+++ b/docs/ext/menus/pagination_examples.rst
@@ -328,8 +328,10 @@ for an example on how to create a :class:`Select Menu <nextcord.ui.Select>`.
 Menu in Slash Command Response
 ------------------------------
 
-To use a menu in a slash command, we need to pass ``interaction`` to :meth:`start() <Menu.start>` 
-as a keyword argument instead of ``ctx``.
+To use a menu in a slash command or component response, we need to pass ``interaction`` to
+:meth:`start() <Menu.start>` as a keyword argument instead of ``ctx``.
+
+To make the response message ephemeral, we can pass ``ephemeral=True`` to :meth:`start() <Menu.start>` as well.
 
 .. code:: py
 

--- a/docs/ext/menus/pagination_examples.rst
+++ b/docs/ext/menus/pagination_examples.rst
@@ -325,6 +325,17 @@ for an example on how to create a :class:`Select Menu <nextcord.ui.Select>`.
         pages = SelectButtonMenuPages(source=MySource(data))
         await pages.start(ctx)
 
+Menu in Slash Command Response
+------------------------------
+
+.. code:: py
+
+    @bot.slash_command(guild_ids=[TEST_GUILD_ID], name="slashpages")
+    async def slash_pages(interaction: nextcord.Interaction):
+        data = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+        pages = SelectButtonMenuPages(source=MySource(data))
+        await pages.start(interaction=interaction)
+
 Paginated Help Command Cog
 --------------------------
 

--- a/docs/ext/menus/pagination_examples.rst
+++ b/docs/ext/menus/pagination_examples.rst
@@ -338,7 +338,7 @@ To make the response message ephemeral, we can pass ``ephemeral=True`` to :meth:
     @bot.slash_command(guild_ids=[TEST_GUILD_ID], name="slashpages")
     async def slash_pages(interaction: nextcord.Interaction):
         data = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
-        pages = SelectButtonMenuPages(source=MySource(data))
+        pages = menus.ButtonMenuPages(source=MySource(data))
         await pages.start(interaction=interaction)
 
 Paginated Help Command Cog

--- a/nextcord/ext/menus/__init__.py
+++ b/nextcord/ext/menus/__init__.py
@@ -6,4 +6,4 @@ from .page_source import *
 from .utils import *
 
 # Needed for the setup.py script
-__version__ = "1.3.4"
+__version__ = "1.4.0"

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -125,6 +125,7 @@ class MenuPagesBase(Menu):
         self,
         ctx: Optional[commands.Context] = None,
         interaction: Optional[nextcord.Interaction] = None,
+        *,
         channel: Optional[nextcord.abc.Messageable] = None,
         wait: Optional[bool] = False,
         ephemeral: bool = False,
@@ -283,7 +284,7 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
         self,
         source: PageSource,
         style: nextcord.ButtonStyle = nextcord.ButtonStyle.secondary,
-        **kwargs
+        **kwargs,
     ):
         self.__button_menu_pages__ = True
         # make button pagination disable buttons on stop by default unless it's overridden

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -122,7 +122,6 @@ class MenuPagesBase(Menu):
     async def start(
         self,
         ctx: Optional[commands.Context] = None,
-        *,
         interaction: Optional[nextcord.Interaction] = None,
         channel: Optional[nextcord.abc.Messageable] = None,
         wait: Optional[bool] = False

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -127,7 +127,7 @@ class MenuPagesBase(Menu):
         interaction: Optional[nextcord.Interaction] = None,
         *,
         channel: Optional[nextcord.abc.Messageable] = None,
-        wait: Optional[bool] = False,
+        wait: bool = False,
         ephemeral: bool = False,
     ):
         await self._source._prepare_once()

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -114,7 +114,9 @@ class MenuPagesBase(Menu):
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
         # if there is an interaction, send an interaction response
         if self.interaction is not None:
-            await self.interaction.response.send_message(**kwargs)
+            await self.interaction.response.send_message(
+                ephemeral=self.ephemeral, **kwargs
+            )
             return await self.interaction.original_message()
         # otherwise, send the message using the channel
         return await channel.send(**kwargs)
@@ -124,10 +126,17 @@ class MenuPagesBase(Menu):
         ctx: Optional[commands.Context] = None,
         interaction: Optional[nextcord.Interaction] = None,
         channel: Optional[nextcord.abc.Messageable] = None,
-        wait: Optional[bool] = False
+        wait: Optional[bool] = False,
+        ephemeral: bool = False,
     ):
         await self._source._prepare_once()
-        await super().start(ctx, interaction=interaction, channel=channel, wait=wait)
+        await super().start(
+            ctx=ctx,
+            interaction=interaction,
+            channel=channel,
+            wait=wait,
+            ephemeral=ephemeral,
+        )
         # If we're not paginating, we can remove the pagination buttons
         if not self._source.is_paginating():
             await self.clear()

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -110,17 +110,25 @@ class MenuPagesBase(Menu):
         """
         page = await self._source.get_page(0)
         kwargs = await self._get_kwargs_from_page(page)
+        # filter out kwargs that are "None"
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        # if there is an interaction, send an interaction response
+        if self.interaction is not None:
+            await self.interaction.response.send_message(**kwargs)
+            return await self.interaction.original_message()
+        # otherwise, send the message using the channel
         return await channel.send(**kwargs)
 
     async def start(
         self,
-        ctx: commands.Context,
+        ctx: Optional[commands.Context] = None,
         *,
+        interaction: Optional[nextcord.Interaction] = None,
         channel: Optional[nextcord.abc.Messageable] = None,
         wait: Optional[bool] = False
     ):
         await self._source._prepare_once()
-        await super().start(ctx, channel=channel, wait=wait)
+        await super().start(ctx, interaction=interaction, channel=channel, wait=wait)
         # If we're not paginating, we can remove the pagination buttons
         if not self._source.is_paginating():
             await self.clear()

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -653,11 +653,9 @@ class Menu(metaclass=_MenuMeta):
         if ctx is not None and interaction is not None:
             raise ValueError("ctx and interaction cannot both be set.")
         # Note: interaction.bot does not exist until nextcord/nextcord#348 is merged
-        self.bot = bot = getattr(ctx, "bot", getattr(interaction, "bot", None))
-        author = getattr(ctx, "author", getattr(interaction, "user", None))
-        self._author_id = getattr(author, "id", None)
-        channel = ctx.channel if ctx and channel is None else channel
-        channel = interaction.channel if interaction else channel
+        self.bot = bot = getattr(ctx, "bot", None) or getattr(interaction, "bot", None)
+        self._author_id = ctx.author.id if ctx else interaction.user.id
+        channel = channel or getattr(ctx, "channel", None) or interaction.channel
         me = channel.guild.me if hasattr(channel, "guild") else ctx.bot.user
         permissions = channel.permissions_for(me)
         self.__me = nextcord.Object(id=me.id)

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -254,6 +254,7 @@ class Menu(metaclass=_MenuMeta):
         message you want to attach a menu to.
     ephemeral: :class:`bool`
         Whether to make the response ephemeral when using an interaction response.
+        Note: Ephemeral messages do not support reactions.
     """
 
     def __init__(
@@ -621,24 +622,26 @@ class Menu(metaclass=_MenuMeta):
         Starts the interactive menu session.
 
         To start a menu session, you must provide either a
-        :class:`Context` or a :class:`nextcord.Interaction` object.
+        :class:`Context <nextcord.ext.commands.Context>` or an :class:`Interaction <nextcord.Interaction>` object.
 
         Parameters
         -----------
-        ctx: :class:`Context`
+        ctx: :class:`Context <nextcord.ext.commands.Context>`
             The invocation context to use.
-        interaction: :class:`Interaction`
+        interaction: :class:`nextcord.Interaction`
             The interaction context to use for slash and
             component responses.
         channel: :class:`nextcord.abc.Messageable`
             The messageable to send the message to. If not given
-            then it defaults to the channel in the context.
+            then it defaults to the channel in the context
+            or interaction.
         wait: :class:`bool`
             Whether to wait until the menu is completed before
             returning back to the caller.
         ephemeral: :class:`bool`
             Whether to make the response ephemeral when using an
-            interaction response.
+            interaction response. Note: ephemeral messages do not
+            support reactions.
 
         Raises
         -------

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -253,7 +253,7 @@ class Menu(metaclass=_MenuMeta):
         calling :meth:`send_initial_message`\, if for example you have a pre-existing
         message you want to attach a menu to.
     ephemeral: :class:`bool`
-            Whether to make the response ephemeral when using an interaction response.
+        Whether to make the response ephemeral when using an interaction response.
     """
 
     def __init__(
@@ -645,7 +645,7 @@ class Menu(metaclass=_MenuMeta):
             An error happened when verifying permissions.
         nextcord.HTTPException
             Adding a reaction failed.
-        TypeError
+        ValueError
             No context or interaction was given or both were given.
         """
 

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -611,6 +611,7 @@ class Menu(metaclass=_MenuMeta):
         self,
         ctx: Optional[commands.Context] = None,
         interaction: Optional[nextcord.Interaction] = None,
+        *,
         channel: Optional[nextcord.abc.Messageable] = None,
         wait: bool = False,
         ephemeral: bool = False,

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -645,6 +645,8 @@ class Menu(metaclass=_MenuMeta):
             An error happened when verifying permissions.
         nextcord.HTTPException
             Adding a reaction failed.
+        TypeError
+            No context or interaction was given or both were given.
         """
 
         # Clear the reaction buttons cache and re-compute if possible.
@@ -661,10 +663,9 @@ class Menu(metaclass=_MenuMeta):
             raise ValueError("ctx or interaction must be set.")
         if ctx is not None and interaction is not None:
             raise ValueError("ctx and interaction cannot both be set.")
-        # Note: interaction.bot does not exist until nextcord/nextcord#348 is merged
-        self.bot = bot = getattr(ctx, "bot", None) or getattr(interaction, "bot", None)
+        self.bot = bot = ctx.bot if ctx else interaction._state._get_client()
         self._author_id = ctx.author.id if ctx else interaction.user.id
-        channel = channel or getattr(ctx, "channel", None) or interaction.channel
+        channel = channel or (ctx.channel if ctx else interaction.channel)
         me = channel.guild.me if hasattr(channel, "guild") else ctx.bot.user
         permissions = channel.permissions_for(me)
         self.__me = nextcord.Object(id=me.id)

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -252,6 +252,8 @@ class Menu(metaclass=_MenuMeta):
         message of :meth:`send_initial_message`. You can set it in order to avoid
         calling :meth:`send_initial_message`\, if for example you have a pre-existing
         message you want to attach a menu to.
+    ephemeral: :class:`bool`
+            Whether to make the response ephemeral when using an interaction response.
     """
 
     def __init__(
@@ -274,6 +276,7 @@ class Menu(metaclass=_MenuMeta):
         self.message = message
         self.ctx = None
         self.interaction = None
+        self.ephemeral = False
         self.bot = None
         self._author_id = None
         self._buttons = self.__class__.get_buttons()
@@ -610,26 +613,31 @@ class Menu(metaclass=_MenuMeta):
         interaction: Optional[nextcord.Interaction] = None,
         channel: Optional[nextcord.abc.Messageable] = None,
         wait: bool = False,
+        ephemeral: bool = False,
     ):
         """|coro|
 
         Starts the interactive menu session.
 
-        To start a menu session, you must provide either a :class:`Context` or
-        a :class:`nextcord.Interaction` object.
+        To start a menu session, you must provide either a
+        :class:`Context` or a :class:`nextcord.Interaction` object.
 
         Parameters
         -----------
         ctx: :class:`Context`
             The invocation context to use.
         interaction: :class:`Interaction`
-            The interaction context to use for slash and component responses.
+            The interaction context to use for slash and
+            component responses.
         channel: :class:`nextcord.abc.Messageable`
             The messageable to send the message to. If not given
             then it defaults to the channel in the context.
         wait: :class:`bool`
             Whether to wait until the menu is completed before
             returning back to the caller.
+        ephemeral: :class:`bool`
+            Whether to make the response ephemeral when using an
+            interaction response.
 
         Raises
         -------
@@ -647,6 +655,7 @@ class Menu(metaclass=_MenuMeta):
 
         self.ctx = ctx
         self.interaction = interaction
+        self.ephemeral = ephemeral
         # ensure only one of ctx and interaction is set
         if ctx is None and interaction is None:
             raise ValueError("ctx or interaction must be set.")


### PR DESCRIPTION
Fixes #26 

This PR allows menus to be sent in response to an interaction such as components and slash commands.

Differences between menus in message commands and slash commands:

`pages.start(interaction=interaction)` will be used in place of `pages.start(ctx)`

Ephemeral responses:

```py
pages.start(interaction=interaction, ephemeral=True)
```

(Note: reaction menus cannot be send with ephemeral due to a Discord limitation)

Sending an initial message with interaction response:

```py
await self.interaction.response.send_message(**kwargs)
return await self.interaction.original_message()
```

----

This version (1.4.0) can be tested early with
```
pip install -U git+https://github.com/DenverCoderOne/nextcord-ext-menus@interaction-response#egg=nextcord-ext-menus
```