### PR TITLE
feat: support send pages after defer

### DIFF
--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 import nextcord
 from nextcord.ext import commands

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -100,9 +100,7 @@ class MenuPagesBase(Menu):
 
     async def send_initial_message(
         self, ctx: commands.Context, channel: nextcord.abc.Messageable
-    ) -> Optional[
-        Union[nextcord.Message, nextcord.InteractionMessage, nextcord.WebhookMessage]
-    ]:
+    ) -> nextcord.Message:
         """|coro|
 
         The default implementation of :meth:`Menu.send_initial_message`

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 import nextcord
 from nextcord.ext import commands
@@ -100,7 +100,9 @@ class MenuPagesBase(Menu):
 
     async def send_initial_message(
         self, ctx: commands.Context, channel: nextcord.abc.Messageable
-    ) -> nextcord.Message:
+    ) -> Optional[
+        Union[nextcord.Message, nextcord.InteractionMessage, nextcord.WebhookMessage]
+    ]:
         """|coro|
 
         The default implementation of :meth:`Menu.send_initial_message`
@@ -114,10 +116,8 @@ class MenuPagesBase(Menu):
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
         # if there is an interaction, send an interaction response
         if self.interaction is not None:
-            await self.interaction.response.send_message(
-                ephemeral=self.ephemeral, **kwargs
-            )
-            return await self.interaction.original_message()
+            message = await self.interaction.send(ephemeral=self.ephemeral, **kwargs)
+            return message or await self.interaction.original_message()
         # otherwise, send the message using the channel
         return await channel.send(**kwargs)
 

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -247,7 +247,7 @@ class Menu(metaclass=_MenuMeta):
     bot: Optional[:class:`commands.Bot`]
         The bot that is running this pagination session or ``None`` if it hasn't
         been started yet.
-    message: Optional[Union[:class:`nextcord.Message`, :class:`nextcord.InteractionMessage`, :class:`nextcord.WebhookMessage`]]
+    message: Optional[:class:`nextcord.Message`]
         The message that has been sent for handling the menu. This is the returned
         message of :meth:`send_initial_message`. You can set it in order to avoid
         calling :meth:`send_initial_message`\, if for example you have a pre-existing
@@ -719,9 +719,7 @@ class Menu(metaclass=_MenuMeta):
 
     async def send_initial_message(
         self, ctx: commands.Context, channel: nextcord.abc.Messageable
-    ) -> Optional[
-        Union[nextcord.Message, nextcord.InteractionMessage, nextcord.WebhookMessage]
-    ]:
+    ) -> nextcord.Message:
         """|coro|
 
         Sends the initial message for the menu session.
@@ -741,7 +739,7 @@ class Menu(metaclass=_MenuMeta):
 
         Returns
         --------
-        Optional[Union[:class:`nextcord.Message`, :class:`nextcord.InteractionMessage`, :class:`nextcord.WebhookMessage`]]
+        :class:`nextcord.Message`
             The message that has been sent.
         """
         raise NotImplementedError
@@ -812,7 +810,7 @@ class ButtonMenu(Menu, nextcord.ui.View):
     bot: Optional[:class:`commands.Bot`]
         The bot that is running this pagination session or ``None`` if it hasn't
         been started yet.
-    message: Optional[Union[:class:`nextcord.Message`, :class:`nextcord.InteractionMessage`, :class:`nextcord.WebhookMessage`]]
+    message: Optional[:class:`nextcord.Message`]
         The message that has been sent for handling the menu. This is the returned
         message of :meth:`send_initial_message`. You can set it in order to avoid
         calling :meth:`send_initial_message`\, if for example you have a pre-existing

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -67,7 +67,7 @@ class Button:
         *,
         skip_if: Optional[Callable[["Menu"], bool]] = None,
         position: Optional[Position] = None,
-        lock: Optional[bool] = True
+        lock: Optional[bool] = True,
     ):
 
         self.emoji = _cast_emoji(emoji)
@@ -247,7 +247,7 @@ class Menu(metaclass=_MenuMeta):
     bot: Optional[:class:`commands.Bot`]
         The bot that is running this pagination session or ``None`` if it hasn't
         been started yet.
-    message: Optional[:class:`nextcord.Message`]
+    message: Optional[Union[:class:`nextcord.Message`, :class:`nextcord.InteractionMessage`, :class:`nextcord.WebhookMessage`]]
         The message that has been sent for handling the menu. This is the returned
         message of :meth:`send_initial_message`. You can set it in order to avoid
         calling :meth:`send_initial_message`\, if for example you have a pre-existing
@@ -264,7 +264,7 @@ class Menu(metaclass=_MenuMeta):
         delete_message_after: bool = False,
         clear_reactions_after: bool = False,
         check_embeds: bool = False,
-        message: Optional[nextcord.Message] = None
+        message: Optional[nextcord.Message] = None,
     ):
 
         self.timeout = timeout
@@ -719,7 +719,9 @@ class Menu(metaclass=_MenuMeta):
 
     async def send_initial_message(
         self, ctx: commands.Context, channel: nextcord.abc.Messageable
-    ) -> nextcord.Message:
+    ) -> Optional[
+        Union[nextcord.Message, nextcord.InteractionMessage, nextcord.WebhookMessage]
+    ]:
         """|coro|
 
         Sends the initial message for the menu session.
@@ -739,7 +741,7 @@ class Menu(metaclass=_MenuMeta):
 
         Returns
         --------
-        :class:`nextcord.Message`
+        Optional[Union[:class:`nextcord.Message`, :class:`nextcord.InteractionMessage`, :class:`nextcord.WebhookMessage`]]
             The message that has been sent.
         """
         raise NotImplementedError
@@ -810,7 +812,7 @@ class ButtonMenu(Menu, nextcord.ui.View):
     bot: Optional[:class:`commands.Bot`]
         The bot that is running this pagination session or ``None`` if it hasn't
         been started yet.
-    message: Optional[:class:`nextcord.Message`]
+    message: Optional[Union[:class:`nextcord.Message`, :class:`nextcord.InteractionMessage`, :class:`nextcord.WebhookMessage`]]
         The message that has been sent for handling the menu. This is the returned
         message of :meth:`send_initial_message`. You can set it in order to avoid
         calling :meth:`send_initial_message`\, if for example you have a pre-existing
@@ -829,7 +831,7 @@ class ButtonMenu(Menu, nextcord.ui.View):
         clear_buttons_after: bool = False,
         disable_buttons_after: bool = False,
         *args,
-        **kwargs
+        **kwargs,
     ):
         Menu.__init__(self, timeout=timeout, *args, **kwargs)
         nextcord.ui.View.__init__(self, timeout=timeout)


### PR DESCRIPTION
The current implementation of `MenuPages` uses `interaction.response.send_message` to send the initial message which does not work if `defer` was used beforehand.

This changes the implementation to use the helper function `Interaction.send` so that it will work even if `defer` was used beforehand.

---

Can be tested with:
```
pip install -U git+https://github.com/DenverCoderOne/nextcord-ext-menus@pages-defer --force-reinstall
```