### PR TITLE
fix: should_add_reactions returning true for Button menu

### DIFF
--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -65,7 +65,7 @@ class MenuPagesBase(Menu):
             await self.show_page(0)
 
     def should_add_reactions(self) -> bool:
-        return len(self.buttons) > 0
+        return self._source.is_paginating() and len(self.buttons) > 0
 
     def should_add_buttons(self) -> bool:
         return self._source.is_paginating()

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -303,7 +303,7 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
             kwargs["disable_buttons_after"] = True
         super().__init__(source, **kwargs)
         # skip adding buttons if inherit_buttons=False was passed to metaclass or only one page
-        if not self.__inherit_buttons__ or not self._source.is_paginating():
+        if not self.__inherit_buttons__ or not self.should_add_buttons():
             return
         # add buttons to the view
         pagination_emojis = (
@@ -320,6 +320,9 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
             self.add_item(MenuPaginationButton(emoji=emoji, style=style))
         # disable buttons that are not available
         self._disable_unavailable_buttons()
+
+    def should_add_buttons(self) -> bool:
+        return self._source.is_paginating()
 
     async def show_page(self, page_number: int):
         """|coro|

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -65,13 +65,13 @@ class MenuPagesBase(Menu):
             await self.show_page(0)
 
     def should_add_reactions(self) -> bool:
-        return self.should_add_reactions_or_buttons()
+        return len(self.buttons) > 0
 
     def should_add_buttons(self) -> bool:
-        return self.should_add_reactions_or_buttons()
+        return self._source.is_paginating()
 
     def should_add_reactions_or_buttons(self) -> bool:
-        return self._source.is_paginating()
+        return self.should_add_reactions() or self.should_add_buttons()
 
     async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
         """|coro|

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -65,13 +65,10 @@ class MenuPagesBase(Menu):
             await self.show_page(0)
 
     def should_add_reactions(self) -> bool:
-        return self._source.is_paginating() and len(self.buttons) > 0
+        return super().should_add_reactions() and self._source.is_paginating()
 
     def should_add_buttons(self) -> bool:
-        return self._source.is_paginating()
-
-    def should_add_reactions_or_buttons(self) -> bool:
-        return self.should_add_reactions() or self.should_add_buttons()
+        return super().should_add_buttons() and self._source.is_paginating()
 
     async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
         """|coro|
@@ -306,7 +303,7 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
             kwargs["disable_buttons_after"] = True
         super().__init__(source, **kwargs)
         # skip adding buttons if inherit_buttons=False was passed to metaclass or only one page
-        if not self.__inherit_buttons__ or not self.should_add_buttons():
+        if not self.__inherit_buttons__ or not self._source.is_paginating():
             return
         # add buttons to the view
         pagination_emojis = (


### PR DESCRIPTION
**Problem:**

`should_add_reactions` is returning true for `MenuPages` when there are no reactions. This makes it check for reactions permissions when it does not need to.

**Solution:**

* `MenuPages.should_add_reactions_or_buttons()` now uses the implementation of `Menu` by returning `self.should_add_reactions() or self.should_add_buttons()`.
* `MenuPages.should_add_reactions()` and `MenuPages.should_add_buttons()` now call their respective super() implementations in addition to checking if paginating.
* In `ButtonMenuPages`, `should_add_buttons()` is overridden to only check if the source is paginating since buttons are added in the constructor and `should_add_buttons()` is checked in the constructor before the buttons are added.