### PR TITLE
Clean up page source docstring

### DIFF
--- a/nextcord/ext/menus/page_source.py
+++ b/nextcord/ext/menus/page_source.py
@@ -55,7 +55,10 @@ class PageSource:
 
     def is_paginating(self) -> bool:
         """An abstract method that notifies the :class:`MenuPagesBase` whether or not
-        to start paginating. This signals whether to add reactions or not.
+        to start paginating.
+
+        This signals whether to add menus to this page source. Menus can either be
+        buttons or reactions depending on the subclass.
 
         Subclasses must implement this.
 


### PR DESCRIPTION
Given this method appears to be used for both reactions *and* buttons, this change makes sense.