### PR TITLE
Refactor type annotations and documentation

### DIFF
--- a/docs/ext/menus/api.rst
+++ b/docs/ext/menus/api.rst
@@ -136,6 +136,14 @@ GroupByPageSource
     :members:
     :inherited-members:
 
+GroupByEntry
+>>>>>>>>>>>>
+
+.. attributetable:: GroupByEntry
+
+.. autoclass:: GroupByEntry
+    :members:
+
 AsyncIteratorPageSource
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/ext/menus/reaction_menus.rst
+++ b/docs/ext/menus/reaction_menus.rst
@@ -131,6 +131,6 @@ For the sake of example, here’s a basic list source that is paginated:
         await pages.start(ctx)
 
 The :meth:`PageSource.format_page` can return either a :class:`str` for content,
-:class:`nextcord.Embed` for an embed, :class:`List[nextcord.Embed]` for
+:class:`nextcord.Embed` for an embed, List[:class:`nextcord.Embed`] for
 sending multiple embeds, or a :class:`dict` to pass into the kwargs
 of :meth:`nextcord.Message.edit`.

--- a/nextcord/ext/menus/constants.py
+++ b/nextcord/ext/menus/constants.py
@@ -10,8 +10,12 @@ log = logging.getLogger(__name__)
 # default timeout parameter for menus in seconds
 DEFAULT_TIMEOUT = 180.0
 
+# type definition for the keyword-arguments that are
+# used in both Message.edit and Messageable.send
+SendKwargsType = Dict[str, Any]
+
 # type definition for possible page formats
-PageFormatType = Union[str, nextcord.Embed, List[nextcord.Embed], Dict[str, Any]]
+PageFormatType = Union[str, nextcord.Embed, List[nextcord.Embed], SendKwargsType]
 
 # type definition for emoji parameters
 EmojiType = Union[str, nextcord.Emoji, nextcord.PartialEmoji]

--- a/nextcord/ext/menus/constants.py
+++ b/nextcord/ext/menus/constants.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 import nextcord
 
@@ -10,12 +10,8 @@ log = logging.getLogger(__name__)
 # default timeout parameter for menus in seconds
 DEFAULT_TIMEOUT = 180.0
 
-# type definition for the keyword-arguments that are
-# used in both Message.edit and Messageable.send
-SendKwargsType = Dict[str, Union[str, nextcord.Embed, nextcord.ui.View, None]]
-
 # type definition for possible page formats
-PageFormatType = Union[str, nextcord.Embed, List[nextcord.Embed], SendKwargsType]
+PageFormatType = Union[str, nextcord.Embed, List[nextcord.Embed], Dict[str, Any]]
 
 # type definition for emoji parameters
 EmojiType = Union[str, nextcord.Emoji, nextcord.PartialEmoji]

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 import nextcord
 from nextcord.ext import commands
 
-from .constants import PageFormatType
+from .constants import PageFormatType, SendKwargsType
 from .menus import Button, ButtonMenu, Menu
 from .page_source import PageSource
 from .utils import First, Last, _cast_emoji
@@ -70,7 +70,7 @@ class MenuPagesBase(Menu):
     def should_add_buttons(self) -> bool:
         return super().should_add_buttons() and self._source.is_paginating()
 
-    async def _get_kwargs_from_page(self, page: List[Any]) -> Dict[str, Any]:
+    async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
         """|coro|
 
         Calls :meth:`PageSource.format_page` and returns a dict of send kwargs
@@ -334,7 +334,7 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
         # show the page
         await super().show_page(page_number)
 
-    async def _get_kwargs_from_page(self, page: List[Any]) -> Dict[str, Any]:
+    async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
         """|coro|
         Calls :meth:`PageSource.format_page` and returns a dict of send kwargs
 

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 import nextcord
 from nextcord.ext import commands

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -1,9 +1,9 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import nextcord
 from nextcord.ext import commands
 
-from .constants import PageFormatType, SendKwargsType
+from .constants import PageFormatType
 from .menus import Button, ButtonMenu, Menu
 from .page_source import PageSource
 from .utils import First, Last, _cast_emoji
@@ -70,7 +70,7 @@ class MenuPagesBase(Menu):
     def should_add_buttons(self) -> bool:
         return super().should_add_buttons() and self._source.is_paginating()
 
-    async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
+    async def _get_kwargs_from_page(self, page: List[Any]) -> Dict[str, Any]:
         """|coro|
 
         Calls :meth:`PageSource.format_page` and returns a dict of send kwargs
@@ -334,7 +334,7 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
         # show the page
         await super().show_page(page_number)
 
-    async def _get_kwargs_from_page(self, page: List[Any]) -> SendKwargsType:
+    async def _get_kwargs_from_page(self, page: List[Any]) -> Dict[str, Any]:
         """|coro|
         Calls :meth:`PageSource.format_page` and returns a dict of send kwargs
 

--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -79,7 +79,7 @@ class MenuPagesBase(Menu):
         --------
         TypeError
             The return value of :meth:`PageSource.format_page` was not a
-            :class:`str`, :class:`nextcord.Embed`, :class:`List[nextcord.Embed]`,
+            :class:`str`, :class:`nextcord.Embed`, List[:class:`nextcord.Embed`],
             or :class:`dict`.
         """
         value: PageFormatType = await nextcord.utils.maybe_coroutine(
@@ -342,7 +342,7 @@ class ButtonMenuPages(MenuPagesBase, ButtonMenu):
         --------
         TypeError
             The return value of :meth:`PageSource.format_page` was not a
-            :class:`str`, :class:`nextcord.Embed`, :class:`List[nextcord.Embed]`,
+            :class:`str`, :class:`nextcord.Embed`, List[:class:`nextcord.Embed`],
             or :class:`dict`.
         """
         kwargs = await super()._get_kwargs_from_page(page)

--- a/nextcord/ext/menus/page_source.py
+++ b/nextcord/ext/menus/page_source.py
@@ -431,3 +431,26 @@ class AsyncIteratorPageSource(PageSource):
             return await self._get_single_page(page_number)
         else:
             return await self._get_page_range(page_number)
+
+    async def format_page(
+        self, menu: Menu, page: Union[DataType, List[DataType]]
+    ) -> PageFormatType:
+        """An abstract method to format the page.
+
+        This works similar to the :meth:`PageSource.format_page` except
+        the type of the ``page`` parameter is documented.
+
+        Parameters
+        ------------
+        menu: :class:`Menu`
+            The menu that wants to format this page.
+        page: Union[Any, List[Any]]
+            The page returned by :meth:`get_page`. This is either a single element
+            if :attr:`per_page` is set to ``1`` or a slice of the sequence otherwise.
+
+        Returns
+        ---------
+        Union[:class:`str`, :class:`nextcord.Embed`, List[:class:`nextcord.Embed`], :class:`dict`]
+            See :meth:`PageSource.format_page`.
+        """
+        raise NotImplementedError

--- a/nextcord/ext/menus/page_source.py
+++ b/nextcord/ext/menus/page_source.py
@@ -197,6 +197,29 @@ class ListPageSource(PageSource):
             base = page_number * self.per_page
             return self.entries[base : base + self.per_page]
 
+    async def format_page(
+        self, menu: Menu, page: Union[DataType, List[DataType]]
+    ) -> PageFormatType:
+        """An abstract method to format the page.
+
+        This works similar to the :meth:`PageSource.format_page` except
+        the type of the ``page`` parameter is documented.
+
+        Parameters
+        ------------
+        menu: :class:`Menu`
+            The menu that wants to format this page.
+        page: Union[Any, List[Any]]
+            The page returned by :meth:`get_page`. This is either a single element
+            if :attr:`per_page` is set to ``1`` or a slice of the sequence otherwise.
+
+        Returns
+        ---------
+        Union[:class:`str`, :class:`nextcord.Embed`, List[:class:`nextcord.Embed`], :class:`dict`]
+            See :meth:`PageSource.format_page`.
+        """
+        raise NotImplementedError
+
 
 KeyType = TypeVar("KeyType")
 

--- a/nextcord/ext/menus/page_source.py
+++ b/nextcord/ext/menus/page_source.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import inspect
 import itertools
 from typing import (
@@ -225,22 +226,19 @@ KeyType = TypeVar("KeyType")
 KeyFuncType = Callable[[DataType], KeyType]
 
 
-class GroupByEntry:
-    """Represents an entry in a :class:`GroupByPageSource`.
+class GroupByEntry(namedtuple("GroupByEntry", "key items")):
+    """Named tuple representing an entry returned by
+    :meth:`GroupByPageSource.get_page` in a :class:`GroupByPageSource`.
 
     Attributes
     ------------
     key: Callable[[Any], Any]
-        A key function to do the grouping with.
+        A key of the :func:`itertools.groupby` function.
     items: Sequence[Any]
         Sequence of paginated items within the group.
     """
 
-    __slots__ = ("key", "items")
-
-    def __init__(self, **kwargs):
-        self.key: KeyFuncType = kwargs.pop("key")
-        self.items: DataType = kwargs.pop("items")
+    __slots__ = ()
 
 
 class GroupByPageSource(ListPageSource):

--- a/nextcord/ext/menus/page_source.py
+++ b/nextcord/ext/menus/page_source.py
@@ -316,7 +316,7 @@ class GroupByPageSource(ListPageSource):
         ------------
         menu: :class:`Menu`
             The menu that wants to format this page.
-        entry
+        entry: GroupByEntry
             The page returned by :meth:`get_page`. This will be a
             :class:`GroupByEntry` with ``key``, representing the key of the
             :func:`itertools.groupby` function, and ``items``, representing

--- a/nextcord/ext/menus/page_source.py
+++ b/nextcord/ext/menus/page_source.py
@@ -123,7 +123,7 @@ class PageSource:
         as returning the ``embed`` keyword argument in :meth:`nextcord.Message.edit`
         and :meth:`nextcord.abc.Messageable.send`.
 
-        If this method returns a :class:`List[nextcord.Embed]` then it is interpreted
+        If this method returns a List[:class:`nextcord.Embed`] then it is interpreted
         as returning the ``embeds`` keyword argument in :meth:`nextcord.Message.edit`
         and :meth:`nextcord.abc.Messageable.send`.
 
@@ -141,7 +141,7 @@ class PageSource:
 
         Returns
         ---------
-        Union[:class:`str`, :class:`nextcord.Embed`, :class:`dict`]
+        Union[:class:`str`, :class:`nextcord.Embed`, List[:class:`nextcord.Embed`], :class:`dict`]
             See above.
         """
         raise NotImplementedError
@@ -281,9 +281,9 @@ class GroupByPageSource(ListPageSource):
 
         Returns
         ---------
-        :class:`dict`
             A dictionary representing keyword-arguments to pass to
             the message related calls.
+        Union[:class:`str`, :class:`nextcord.Embed`, List[:class:`nextcord.Embed`], :class:`dict`]
         """
         raise NotImplementedError
 

--- a/nextcord/ext/menus/page_source.py
+++ b/nextcord/ext/menus/page_source.py
@@ -234,11 +234,14 @@ class GroupByEntry(namedtuple("GroupByEntry", "key items")):
     ------------
     key: Callable[[Any], Any]
         A key of the :func:`itertools.groupby` function.
-    items: Sequence[Any]
-        Sequence of paginated items within the group.
+    items: List[Any]
+        Slice of the paginated items within the group.
     """
 
     __slots__ = ()
+
+    key: KeyFuncType
+    items: List[DataType]
 
 
 class GroupByPageSource(ListPageSource):

--- a/nextcord/ext/menus/page_source.py
+++ b/nextcord/ext/menus/page_source.py
@@ -236,10 +236,11 @@ class GroupByEntry:
         Sequence of paginated items within the group.
     """
 
-    __slots__ = ('key', 'items')
+    __slots__ = ("key", "items")
 
-    key: KeyFuncType
-    items: DataType
+    def __init__(self, **kwargs):
+        self.key: KeyFuncType = kwargs.pop("key")
+        self.items: DataType = kwargs.pop("items")
 
 
 class GroupByPageSource(ListPageSource):


### PR DESCRIPTION
### Changes

1. Fixed rst List documentation from :class:\`List[nextcord.Embed]\` to List[:class:\`nextcord.Embed\`] for proper linking.
2. Documented the type of `page` in `ListPageSource.format_page` and `AsyncIteratorPageSource.format_page`
3. Renamed `_GroupByEntry` named tuple to `GroupByEntry` and documented the class.
4. Change type of `SendKwargsType` to allow any type to appear in the send kwargs returned by `format_page`. This includes files, stickers, bool, AllowedMentions, etc. to be passed in the kwargs dict.