### PR TITLE
fix: Clear buttons before sending if one page async iterator source

### DIFF
--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -125,6 +125,9 @@ class MenuPagesBase(Menu):
         kwargs = await self._get_kwargs_from_page(page)
         # filter out kwargs that are "None"
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        # if we're not paginating, we can remove the pagination buttons
+        if not self._source.is_paginating():
+            await self.clear()
         # if there is an interaction, send an interaction response
         if self.interaction is not None:
             message = await self.interaction.send(ephemeral=self.ephemeral, **kwargs)
@@ -149,9 +152,6 @@ class MenuPagesBase(Menu):
             wait=wait,
             ephemeral=ephemeral,
         )
-        # If we're not paginating, we can remove the pagination buttons
-        if not self._source.is_paginating():
-            await self.clear()
 
     async def show_checked_page(self, page_number: int):
         max_pages = self._source.get_max_pages()

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -855,7 +855,7 @@ class ButtonMenu(Menu, nextcord.ui.View):
     async def _set_all_disabled(self, disable: bool):
         """|coro|
 
-        Enables or disable all :class:`nextcord.ui.Button` components in the menu. If the :attr:`message` is set,
+        Enables or disables all :class:`nextcord.ui.Button` components in the menu. If the :attr:`message` is set,
         it will be edited with the new :class:`~nextcord.ui.View`.
 
         If no buttons are enabled or disabled, the message will not be edited.
@@ -902,7 +902,7 @@ class ButtonMenu(Menu, nextcord.ui.View):
         Removes all :class:`nextcord.ui.Button` components in the menu. If the :attr:`message` is set,
         it will be edited with the new :class:`~nextcord.ui.View`.
 
-        If there are already no items in the view, the message will not be edited.
+        If there are already no buttons in the view, the message will not be edited.
         """
         # if there are no buttons, then we don't need to do anything
         modified = False


### PR DESCRIPTION
## Summary

There is a small issue with AsyncIterator page sources where if a menu requires only 1 page, the buttons will be created but then removed within a second. This happens because `is_paginating` is not able to determine if more than 1 page is needed until the first page is read. This will also apply to any custom page sources where the former applies. Currently the buttons are cleared in `start()`, after the menu has been sent.

This PR makes it so that the buttons are removed from the view after the page is read, but **before** it is sent so that it doesn't need to be edited afterwards.

Additionally, `ButtonMenu.clear()` was updated to only remove `nextcord.ui.Button` objects. This was done since it is what is already written in the docstring and is consistent with `disable()` and `enable()`.

## Changes

* Moves the call to `self.clear()` into `send_initial_message` instead of `start` so that with async iterator page source, it will not send the buttons if there is only one page.

* `ButtonMenu.clear()` was fixed to only clear _buttons_ and not all items, and additionally not call `message.edit` if message is `None`.

* For consistency and performance, `ButtonMenu.disable()` and `ButtonMenu.enable()` similarly will not edit the message if the view has not changed.

## Potentially breaking

* `ButtonMenu.clear()` will now only clear Buttons. The docstring for this method already said that it would clear Buttons, but the implementation has been changed to make it so that other types of items (eg. select menus) will no longer be removed.

* If a user is overriding `send_initial_message` in a subclass of `ButtonMenuPages` and sends a pagination menu that only requires 1 page, the buttons may no longer be cleared since the clearing now only happens in the default implementation of `ButtonMenuPages.send_initial_message`.

## Gifs

<details><summary>Before</summary>
<img src="https://user-images.githubusercontent.com/20955511/170604294-54244165-92d0-4cfd-a1cb-7f46ea52379c.gif" alt="old" />
</details>

<details><summary>After</summary>
<img src="https://user-images.githubusercontent.com/20955511/170604293-257d6bad-8e00-4222-a35f-9783cf30cf89.gif" alt="old" />
</details>