### PR TITLE
fix: Adding reactions to interaction response in menu pages

### DIFF
--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 import nextcord
 from nextcord.ext import commands
@@ -110,7 +110,7 @@ class MenuPagesBase(Menu):
 
     async def send_initial_message(
         self, ctx: commands.Context, channel: nextcord.abc.Messageable
-    ) -> nextcord.Message:
+    ) -> Union[nextcord.Message, nextcord.PartialInteractionMessage]:
         """|coro|
 
         The default implementation of :meth:`Menu.send_initial_message`
@@ -128,7 +128,11 @@ class MenuPagesBase(Menu):
         # if there is an interaction, send an interaction response
         if self.interaction is not None:
             message = await self.interaction.send(ephemeral=self.ephemeral, **kwargs)
-            return message or await self.interaction.original_message()
+            # if we are adding reactions, we need the full interaction message
+            if isinstance(message, nextcord.PartialInteractionMessage) and self.buttons:
+                return await self.interaction.original_message()
+            # if we are only adding view buttons, we can return a PartialInteractionMessage or WebhookMessage
+            return message
         # otherwise, send the message using the channel
         return await channel.send(**kwargs)
 

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -831,7 +831,7 @@ class ButtonMenu(Menu, nextcord.ui.View):
     bot: Optional[:class:`commands.Bot`]
         The bot that is running this pagination session or ``None`` if it hasn't
         been started yet.
-    message: Optional[:class:`nextcord.Message`, :class:`nextcord.PartialInteractionMessage`]
+    message: Optional[Union[:class:`nextcord.Message`, :class:`nextcord.PartialInteractionMessage`]]
         The message that has been sent for handling the menu. This is the returned
         message of :meth:`send_initial_message`. You can set it in order to avoid
         calling :meth:`send_initial_message`\, if for example you have a pre-existing

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -256,7 +256,8 @@ class Menu(metaclass=_MenuMeta):
         The message that has been sent for handling the menu. This is the returned
         message of :meth:`send_initial_message`. You can set it in order to avoid
         calling :meth:`send_initial_message`\, if for example you have a pre-existing
-        message you want to attach a menu to.
+        message you want to attach a menu to. When using reaction buttons, the
+        message must be an instance of a :class:`nextcord.Message`.
     ephemeral: :class:`bool`
         Whether to make the response ephemeral when using an interaction response.
         Note: Ephemeral messages do not support reactions.
@@ -740,6 +741,11 @@ class Menu(metaclass=_MenuMeta):
         Sends the initial message for the menu session.
 
         This is internally assigned to the :attr:`message` attribute.
+
+        A :class:`~nextcord.Message` or a
+        :class:`~nextcord.PartialInteractionMessage` object must be
+        returned. When using reaction buttons, the message must be
+        an instance of a :class:`nextcord.Message`.
 
         Subclasses must implement this if they don't set the
         :attr:`message` attribute themselves before starting the

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -754,7 +754,7 @@ class Menu(metaclass=_MenuMeta):
 
         Returns
         --------
-        :class:`nextcord.Message`
+        Union[:class:`nextcord.Message`, :class:`nextcord.PartialInteractionMessage`]
             The message that has been sent.
         """
         raise NotImplementedError

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -252,7 +252,7 @@ class Menu(metaclass=_MenuMeta):
     bot: Optional[:class:`commands.Bot`]
         The bot that is running this pagination session or ``None`` if it hasn't
         been started yet.
-    message: Optional[:class:`nextcord.Message`]
+    message: Optional[Union[:class:`nextcord.Message`, :class:`nextcord.PartialInteractionMessage`]]
         The message that has been sent for handling the menu. This is the returned
         message of :meth:`send_initial_message`. You can set it in order to avoid
         calling :meth:`send_initial_message`\, if for example you have a pre-existing
@@ -269,7 +269,7 @@ class Menu(metaclass=_MenuMeta):
         delete_message_after: bool = False,
         clear_reactions_after: bool = False,
         check_embeds: bool = False,
-        message: Optional[nextcord.Message] = None,
+        message: Optional[Union[nextcord.Message, nextcord.PartialInteractionMessage]] = None,
     ):
 
         self.timeout = timeout
@@ -345,7 +345,9 @@ class Menu(metaclass=_MenuMeta):
             if self.__tasks:
 
                 async def wrapped():
-                    assert self.message is not None
+                    assert isinstance(
+                        self.message, nextcord.Message
+                    ), "Message must be a nextcord.Message to add reactions"
                     # Add the reaction
                     await self.message.add_reaction(button.emoji)
                     # Update the cache to have the value
@@ -394,7 +396,9 @@ class Menu(metaclass=_MenuMeta):
             if self.__tasks:
 
                 async def wrapped():
-                    assert self.message is not None
+                    assert isinstance(
+                        self.message, nextcord.Message
+                    ), "Message must be a nextcord.Message to remove reactions"
                     # Remove the reaction from being processable
                     # Removing it from the cache first makes it so the check
                     # doesn't get triggered.
@@ -704,6 +708,9 @@ class Menu(metaclass=_MenuMeta):
 
             async def add_reactions_task():
                 for emoji in self.buttons:
+                    assert isinstance(
+                        msg, nextcord.Message
+                    ), "Message must be a nextcord.Message to add reactions"
                     await msg.add_reaction(emoji)
 
             self.__tasks.append(self.bot.loop.create_task(add_reactions_task()))
@@ -727,7 +734,7 @@ class Menu(metaclass=_MenuMeta):
 
     async def send_initial_message(
         self, ctx: Optional[commands.Context], channel: Optional[nextcord.abc.Messageable]
-    ) -> nextcord.Message:
+    ) -> Union[nextcord.Message, nextcord.PartialInteractionMessage]:
         """|coro|
 
         Sends the initial message for the menu session.
@@ -767,7 +774,9 @@ class Menu(metaclass=_MenuMeta):
                 except AttributeError:
                     pass
                 finally:
-                    assert self.message is not None, "Cannot remove reactions without a message."
+                    assert isinstance(
+                        self.message, nextcord.Message
+                    ), "Message must be a nextcord.Message to remove reactions"
                     await self.message.clear_reactions()
                 return
 
@@ -780,7 +789,9 @@ class Menu(metaclass=_MenuMeta):
 
             for reaction in reactions:
                 try:
-                    assert self.message is not None, "Cannot remove reactions without a message."
+                    assert isinstance(
+                        self.message, nextcord.Message
+                    ), "Message must be a nextcord.Message to remove reactions"
                     await self.message.remove_reaction(reaction, self.__me)
                 except nextcord.HTTPException:
                     continue
@@ -820,7 +831,7 @@ class ButtonMenu(Menu, nextcord.ui.View):
     bot: Optional[:class:`commands.Bot`]
         The bot that is running this pagination session or ``None`` if it hasn't
         been started yet.
-    message: Optional[:class:`nextcord.Message`]
+    message: Optional[:class:`nextcord.Message`, :class:`nextcord.PartialInteractionMessage`]
         The message that has been sent for handling the menu. This is the returned
         message of :meth:`send_initial_message`. You can set it in order to avoid
         calling :meth:`send_initial_message`\, if for example you have a pre-existing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-nextcord
+nextcord>=2.0.0b1


### PR DESCRIPTION
If there are reaction buttons, the full InteractionMessage must be fetched when send returns a PartialInteractionMessage.

PartialInteractionMessage does not support add_reactions, so it should not be returned when self.buttons contains elements.

This was working prior to nextcord 2.0.0b1 due to a statement that was intended to be future-proof:

```py
message = await self.interaction.send(ephemeral=self.ephemeral, **kwargs)
return message or await self.interaction.original_message()
```

As prior to 2.0.0b1, `message` would always be `None`, this worked fine. When using nextcord 2.0.0b1 or later, this does not work for reaction menus.

**BREAKING CHANGE**

As this module now uses `nextcord.PartialInteractionMessage` in type checks, nextcord >= 2.0.0b1 is now required to run the module. When using 2.0.0a10 or earlier, there will be an error, `module 'nextcord' has no attribute 'PartialInteractionMessage'`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
