### PR TITLE
fix: Prevent CannotSendMessages or CannotEmbedLinks on interaction

### DIFF
--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -469,9 +469,10 @@ class Menu(metaclass=_MenuMeta):
         permissions: Permissions,
     ):
         is_thread = isinstance(channel, nextcord.Thread)
-        if is_thread and not permissions.send_messages_in_threads:
-            raise CannotSendMessages()
-        elif not is_thread and not permissions.send_messages:
+        if ctx is not None and (
+            (is_thread and not permissions.send_messages_in_threads)
+            or (not is_thread and not permissions.send_messages)
+        ):
             raise CannotSendMessages()
 
         if self.check_embeds and not permissions.embed_links:

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -475,7 +475,7 @@ class Menu(metaclass=_MenuMeta):
         ):
             raise CannotSendMessages()
 
-        if self.check_embeds and not permissions.embed_links:
+        if ctx is not None and self.check_embeds and not permissions.embed_links:
             raise CannotEmbedLinks()
 
         self._can_remove_reactions = permissions.manage_messages


### PR DESCRIPTION
## Summary

Bots can send interaction responses even when the Send Messages permission is not enabled.

Bots can also send embeds even when Embed Links permission is not enabled.

This skips the check for the permission if an interaction is used instead of ctx.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
