### PR TITLE
refactor: fix pyright issue with message.id

### DIFF
--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -501,7 +501,7 @@ class Menu(metaclass=_MenuMeta):
         :class:`bool`
             Whether the payload should be processed.
         """
-        if self.message is None:
+        if not isinstance(self.message, nextcord.Message):
             return False
         if payload.message_id != self.message.id:
             return False


### PR DESCRIPTION
## Summary

Fixes pyright error
```py
/home/runner/work/nextcord-ext-menus/nextcord-ext-menus/nextcord/ext/menus/menus.py
  /home/runner/work/nextcord-ext-menus/nextcord-ext-menus/nextcord/ext/menus/menus.py:506:47 - error: Cannot access member "id" for type "PartialInteractionMessage"
    Member "id" is unknown (reportGeneralTypeIssues)
```

Reaction Menus require a Message object which is asserted elsewhere in the code, so if `self.message` is a `PartialInteractionMessage` or `None`, we don't need to check the reactions.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
