### PR TITLE
fix: Use channel if overridden in start with interaction

### DIFF
--- a/nextcord/ext/menus/menu_pages.py
+++ b/nextcord/ext/menus/menu_pages.py
@@ -126,7 +126,8 @@ class MenuPagesBase(Menu):
         if not self._source.is_paginating():
             await self.clear()
         # if there is an interaction, send an interaction response
-        if self.interaction is not None:
+        # unless the user has specified a different channel than the interaction channel
+        if self.interaction is not None and channel == self.interaction.channel:
             message = await self.interaction.send(ephemeral=self.ephemeral, **kwargs)
             # if we are adding reactions, we need the full interaction message
             if isinstance(message, nextcord.PartialInteractionMessage) and self.buttons:


### PR DESCRIPTION
## Summary

### Issue:

Specifying `channel` in `MenuPages.start()` gets ignored when `interaction` is passed instead of `ctx`.

### Solution:

If `channel` is specified to be a channel other than the interaction channel, `channel.send` will be used instead of `interaction.send`.

Note: In this situation, the user should be sending an interaction response before starting the menu.

### Example / Test

```py
@bot.slash_command()
async def interaction_channel_example(interaction: Interaction, channel: nextcord.TextChannel):
    await interaction.send(f"Your menu will appear in {channel.mention}", ephemeral=True)
    pages = menus.ButtonMenuPages(source=MySource([f"Entry {i}" for i in range(1, 21)]))
    await pages.start(interaction=interaction, channel=channel)
```

![image](https://user-images.githubusercontent.com/20955511/197677607-2e1582c9-9b5e-4827-ac90-3ecbfc1f1fba.png)

![image](https://user-images.githubusercontent.com/20955511/197677604-0e2881c0-191c-4dbf-a064-2f89cb9ec7ca.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
