### PR TITLE
docs: Fix dark mode toggle for new sphinx book theme

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -22,12 +22,12 @@ div#site-navigation div.navbar_extra_footer {
     font-size: 0.8em;
 }
 
-.topbar-main {
+.header-article__right {
     opacity: 0;
     transition: 0.1s ease-in;
 }
 
-.topbar .topbar-main a.dark-mode-button {
+.header-article__right a.dark-mode-button {
     height: auto;
     float: right;
 }

--- a/docs/_static/js/toggleDarkMode.js
+++ b/docs/_static/js/toggleDarkMode.js
@@ -32,14 +32,14 @@ function toggleDarkMode() {
 }
 
 window.addEventListener("load", function () {
-    const topbar = document.querySelector(".topbar-main");
-    topbar.innerHTML += `<a class="dark-mode-button" title="Toggle dark mode">
-            <button type="button" class="btn btn-secondary topbarbtn"
-                data-toggle="tooltip" data-placement="bottom" onclick="toggleDarkMode()"
-                aria-label="Toggle dark mode" title="" data-original-title="Toggle dark mode">
+    const topbar = document.querySelector(".header-article__right");
+    topbar.innerHTML += `<button type="button" class="headerbtn" data-toggle="tooltip"
+                data-placement="bottom" onclick="toggleDarkMode()" aria-label="Toggle dark mode"
+                title="" data-original-title="Toggle dark mode">
+                <span class="headerbtn__icon-container">
                     <i class="fas fa-moon"></i>
-            </button>
-        </a>`;
+                </span>
+            </button>`;
     topbar.style.opacity = "1";
     if (getCookie("darkmode") == "true") {
         DarkReader.enable();

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ extras_require = {
     "docs": [
         "sphinx",
         "sphinxcontrib_trio",
-        "sphinx-book-theme",
+        "sphinx-book-theme==0.3.3",
     ],
 }
 


### PR DESCRIPTION
## Summary

The dark mode toggle was not appearing in the latest version of the docs due to changes in the class names for sphinx book theme.

This updates my toggleDarkMode script to use the correct class name for adding the dark mode toggle to the header, makes it consistent with the new HTML structure, and updates the dependency to be *fixed* at 0.3.3.

![Peek 2022-10-30 12-26](https://user-images.githubusercontent.com/20955511/198895133-0b82909c-d90a-4549-8e7c-c4b96d01f3c2.gif)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
