### PR TITLE
docs: Fix duplicate members in GroupByEntry

### DIFF
--- a/docs/ext/menus/api.rst
+++ b/docs/ext/menus/api.rst
@@ -142,7 +142,6 @@ GroupByEntry
 .. attributetable:: GroupByEntry
 
 .. autoclass:: GroupByEntry
-    :members:
 
 AsyncIteratorPageSource
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def requirements():
 
 extras_require = {
     "docs": [
-        "sphinx",
+        "sphinx>=5.0.0",
         "sphinxcontrib_trio",
         "sphinx-book-theme==0.3.3",
     ],

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def requirements():
 
 extras_require = {
     "docs": [
-        "sphinx>=5.0.0",
+        "sphinx",
         "sphinxcontrib_trio",
         "sphinx-book-theme==0.3.3",
     ],


### PR DESCRIPTION
## Summary

GroupByEntry was showing duplicate entries for `key` and `items` in Sphinx 5.x.

This fixes the issue by removing `:members:` (Thanks https://stackoverflow.com/a/63637956/11608064)

![image](https://user-images.githubusercontent.com/20955511/198895306-badcd778-b8b3-48a9-8de7-a95a7a957ec5.png)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
