### PR TITLE
fix: Permissions error with interaction menus in DM channels

### DIFF
--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -692,7 +692,7 @@ class Menu(metaclass=_MenuMeta):
             raise ValueError("ctx or interaction must be set.")
         me: Union[Member, ClientUser] = channel.guild.me if hasattr(channel, "guild") else self.bot.user  # type: ignore
         permissions = Permissions.all()
-        if hasattr(interaction, "app_permissions"):
+        if interaction is not None:
             permissions = interaction.app_permissions
         elif hasattr(channel, "permissions_for"):
             permissions = channel.permissions_for(me)  # type: ignore

--- a/nextcord/ext/menus/menus.py
+++ b/nextcord/ext/menus/menus.py
@@ -691,7 +691,11 @@ class Menu(metaclass=_MenuMeta):
         else:
             raise ValueError("ctx or interaction must be set.")
         me: Union[Member, ClientUser] = channel.guild.me if hasattr(channel, "guild") else self.bot.user  # type: ignore
-        permissions = channel.permissions_for(me)  # type: ignore
+        permissions = Permissions.all()
+        if hasattr(interaction, "app_permissions"):
+            permissions = interaction.app_permissions
+        elif hasattr(channel, "permissions_for"):
+            permissions = channel.permissions_for(me)  # type: ignore
         self.__me = nextcord.Object(id=me.id)
         self._verify_permissions(ctx, channel, permissions)
         self._event.clear()


### PR DESCRIPTION
## Summary

Fixes https://discord.com/channels/881118111967883295/1132658144133255178 (`#ext-menus (deesiigneer#0)`)

`Interaction.channel` is of type `PartialMessageable` when the channel is a DM channel which causes an error when trying to call `channel.permissions_for(me)`.

To fix this, we can use `interaction.app_permissions` whenever it is available.

This also adds support for passing a `PartialMessageable` as the `channel` parameter by assuming all permissions.

----

Test package early with:
`pip install git+https://github.com/nextcord/nextcord-ext-menus.git@0ff6f0b33955bf3231f734642dad617d9d494c18#egg=nextcord-ext-menus`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
